### PR TITLE
Implement leaderelection type getter via restmapper

### DIFF
--- a/pkg/client/apiutil/apimachinery.go
+++ b/pkg/client/apiutil/apimachinery.go
@@ -36,6 +36,9 @@ import (
 func NewDiscoveryRESTMapper(c *rest.Config) (meta.RESTMapper, error) {
 	// Get a mapper
 	dc := discovery.NewDiscoveryClientForConfigOrDie(c)
+
+	// TODO(mszostok): here we have useful info about all supported groups and resource
+	// in api-server
 	gr, err := restmapper.GetAPIGroupResources(dc)
 	if err != nil {
 		return nil, err

--- a/pkg/leaderelection/leader_election.go
+++ b/pkg/leaderelection/leader_election.go
@@ -43,6 +43,10 @@ type Options struct {
 	// LeaderElectionID determines the name of the configmap that leader election
 	// will use for holding the leader lock.
 	LeaderElectionID string
+
+	// LeaderElectionLockType determines leader election lock type for holding
+	// the leader lock information.
+	LeaderElectionLockType LockType
 }
 
 // NewResourceLock creates a new config map resource lock for use in a leader
@@ -80,7 +84,7 @@ func NewResourceLock(config *rest.Config, recorderProvider recorder.Provider, op
 	}
 
 	// TODO(JoelSpeed): switch to leaderelection object in 1.12
-	return resourcelock.New(resourcelock.ConfigMapsResourceLock,
+	return resourcelock.New(options.LeaderElectionLockType.Name(),
 		options.LeaderElectionNamespace,
 		options.LeaderElectionID,
 		client.CoreV1(),

--- a/pkg/leaderelection/leader_lock_types.go
+++ b/pkg/leaderelection/leader_lock_types.go
@@ -1,0 +1,50 @@
+package leaderelection
+
+import (
+	"fmt"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+)
+
+type LockType int
+
+const (
+	UndefinedResourceLock LockType = iota
+	ConfigMapsResourceLock
+	LeasesResourceLock
+	EndpointsResourceLock
+)
+
+func (l LockType) Name() string {
+	switch l {
+	case EndpointsResourceLock:
+		return resourcelock.EndpointsResourceLock
+	case ConfigMapsResourceLock:
+		return resourcelock.ConfigMapsResourceLock
+	case LeasesResourceLock:
+		return resourcelock.LeasesResourceLock
+	default:
+		return ""
+	}
+}
+
+// GetPreferredLockType chooses the Lease lock if `lease.coordination.k8s.io` is available.
+// Otherwise, the ConfigMap resource lock is used.
+func GetPreferredLockType(mapper meta.RESTMapper) (LockType, error) {
+	// check if new leader election api is available
+	_, err := mapper.RESTMapping(schema.GroupKind{
+		Kind:  "Lease",
+		Group: coordinationv1.GroupName,
+	})
+	switch {
+	case err == nil:
+		return LeasesResourceLock, nil
+	case meta.IsNoMatchError(err):
+		return ConfigMapsResourceLock, nil
+	default:
+		return UndefinedResourceLock, fmt.Errorf("unable to retrieve supported server groups: %v", err)
+	}
+}


### PR DESCRIPTION
**Description**

This PR is just draft to show the implementation of leaderelection type getter via restmapper. With such implementation we are not calling the api-sever to get all supported groups